### PR TITLE
Local Storage to prevent extra API-calls

### DIFF
--- a/src/Competitive/CompetitiveGame.js
+++ b/src/Competitive/CompetitiveGame.js
@@ -23,31 +23,34 @@ const CompetitiveGame = () => {
       setUser(storedUser);
     }
     const fetchRoundData = async () => {
-      try {
-        const response = await fetch(
-          `https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/rounds/current_competitive_round`
-        );
-        if (!response.ok) {
-          throw new Error("Failed to fetch competitive round data");
+      if(!localStorage.getItem("CompetitiveRoundData")) {
+        try {
+          const response = await fetch(
+            `https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/rounds/current_competitive_round`
+          );
+          if (!response.ok) {
+            throw new Error("Failed to fetch competitive round data");
+          }
+          const data = await response.json();
+          setRound(data.data.id);
+          const competitiveRoundData = {
+            maxtemp: data.data.attributes.maxtemp_f,
+            mintemp: data.data.attributes.mintemp_f,
+            maxwind: data.data.attributes.maxwind_mph,
+            avghumidity: data.data.attributes.avghumidity,
+            totalprecip: data.data.attributes.totalprecip_in,
+          };
+          setRoundLocation({
+            location_name: data.data.attributes.location_name,
+            country: data.data.attributes.country,
+          });
+          localStorage.setItem("CompetitiveRoundData", JSON.stringify(competitiveRoundData))
+          console.log("Fetched round data:", data);
+        } catch (error) {
+          console.error("Error fetching round data:", error);
         }
-        const data = await response.json();
-        setRound(data.data.id);
-        setRoundData({
-          maxtemp: data.data.attributes.maxtemp_f,
-          mintemp: data.data.attributes.mintemp_f,
-          maxwind: data.data.attributes.maxwind_mph,
-          avghumidity: data.data.attributes.avghumidity,
-          totalprecip: data.data.attributes.totalprecip_in,
-        });
-        setRoundLocation({
-          location_name: data.data.attributes.location_name,
-          country: data.data.attributes.country,
-        });
-
-        console.log("Fetched round data:", data);
-      } catch (error) {
-        console.error("Error fetching round data:", error);
       }
+      setRoundData(JSON.parse(localStorage.getItem("CompetitiveRoundData")))
     };
 
     fetchRoundData();

--- a/src/DailyGame/DailyGame.tsx
+++ b/src/DailyGame/DailyGame.tsx
@@ -47,31 +47,39 @@ const DailyGame: React.FC = () => {
       return navigate('../login')
     }
     const storedUser = JSON.parse(localStorage.getItem('User'))
-    if(storedUser) {setUser(storedUser)};
+    if(storedUser) {
+      setUser(storedUser)
+    };
     const fetchRoundData = async () => {
-      try {
-        const response = await fetch(`https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/users/${storedUser.id}/rounds/current_daily_round`);
-        if (!response.ok) {
-          throw new Error('Failed to fetch daily round data');
+      if(!localStorage.getItem("DailyRoundData")) {
+        try {
+          const response = await fetch(`https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/users/${storedUser.id}/rounds/current_daily_round`);
+          if (!response.ok) {
+            throw new Error('Failed to fetch daily round data');
+          }
+          const data = await response.json();
+
+          const dailyRoundData = {
+            maxtemp: data.data.attributes.maxtemp_f, 
+            mintemp: data.data.attributes.mintemp_f,
+            maxwind: data.data.attributes.maxwind_mph,
+            avghumidity: data.data.attributes.avghumidity,
+            totalprecip: data.data.attributes.totalprecip_in
+          };
+          localStorage.setItem("DailyRoundData", JSON.stringify(dailyRoundData));
+
+          setRoundLocation({
+            location_name: data.data.attributes.location_name,
+            country: data.data.attributes.country
+          })
+
+          console.log("fetched data", data)
+        } catch (error) {
+          console.error("Error fetching round data:", error);
         }
-        const data = await response.json();
-
-        setRoundData({
-          maxtemp: data.data.attributes.maxtemp_f, 
-          mintemp: data.data.attributes.mintemp_f,
-          maxwind: data.data.attributes.maxwind_mph,
-          avghumidity: data.data.attributes.avghumidity,
-          totalprecip: data.data.attributes.totalprecip_in
-        });
-        setRoundLocation({
-          location_name: data.data.attributes.location_name,
-          country: data.data.attributes.country
-        })
-
-        console.log("fetched data", data)
-      } catch (error) {
-        console.error("Error fetching round data:", error);
       }
+      console.log('TEST', localStorage.getItem("DailyRoundData"))
+      setRoundData(JSON.parse(localStorage.getItem("DailyRoundData")))
     };
 
     fetchRoundData();

--- a/src/Dashboard/Dashboard.tsx
+++ b/src/Dashboard/Dashboard.tsx
@@ -38,96 +38,102 @@ const Dashboard: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const navigate = useNavigate();
+
   useEffect(() => {
     if(!localStorage.getItem('User')){
       return navigate('../login')
     }
     const storedUser = JSON.parse(localStorage.getItem('User'))
     const fetchRoundData = async () => {
-      try {
-        const response = await fetch(`https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/users/${storedUser.id}/daily_stats`);
-        if (!response.ok) {
-          throw new Error('Failed to fetch daily round data');
+      if(!localStorage.getItem("DailyStats")) {
+        try {
+          const response = await fetch(`https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/users/${storedUser.id}/daily_stats`);
+          if (!response.ok) {
+            throw new Error('Failed to fetch daily round data');
+          }
+          const data = await response.json();
+          
+          const dailyStats = {
+            gameCount: data.daily_stats.daily_game_count, 
+            avgScore: data.daily_stats.average_score_in_daily_games,
+            date: data.daily_stats.date_and_score_of_best_daily_score.date,
+            bestScore: data.daily_stats.date_and_score_of_best_daily_score.score,
+            level1: data.daily_stats.grade_book_daily_round["0.00-500.00"],
+            level2: data.daily_stats.grade_book_daily_round["500.01-1000.00"],
+            level3: data.daily_stats.grade_book_daily_round["1000.01-2000.00"],
+            level4: data.daily_stats.grade_book_daily_round["2000.01-5000.00"],
+            level5: data.daily_stats.grade_book_daily_round["5000.01+"],
+          };
+          setDailyStatsData(dailyStats);
+          localStorage.setItem("DailyStats", JSON.stringify(dailyStats));
+          console.log('Daily stats', localStorage.getItem("DailyStats"))
+          console.log("fetched data", data);
+
+        } catch(error) {
+          setError(error.message);
         }
-        const data = await response.json();
-
-        setDailyStatsData({
-          gameCount: data.daily_stats.daily_game_count, 
-          avgScore: data.daily_stats.average_score_in_daily_games,
-          date: data.daily_stats.date_and_score_of_best_daily_score.date,
-          bestScore: data.daily_stats.date_and_score_of_best_daily_score.score,
-          level1: data.daily_stats.grade_book_daily_round["0.00-500.00"],
-          level2: data.daily_stats.grade_book_daily_round["500.01-1000.00"],
-          level3: data.daily_stats.grade_book_daily_round["1000.01-2000.00"],
-          level4: data.daily_stats.grade_book_daily_round["2000.01-5000.00"],
-          level5: data.daily_stats.grade_book_daily_round["5000.01+"],
-        });
-
-        console.log("fetched data", data);
-
-      } catch(error) {
-        setError(error.message);
       }
+      setDailyStatsData(JSON.parse(localStorage.getItem('DailyStats')));
     };
     const fetchCustomData = async () => {
-      console.log("Fetching custom data...");
-      try {
-        const response = await fetch(`https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/users/${storedUser.id}/games`);
-        if (!response.ok) {
-          throw new Error('Failed to fetch daily round data');
+      if(!localStorage.getItem('CustomGames')) {
+        console.log("Fetching custom data...");
+        try {
+          const response = await fetch(`https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/users/${storedUser.id}/games`);
+          if (!response.ok) {
+            throw new Error('Failed to fetch daily round data');
+          }
+          const responseData = await response.json();
+      
+          // Extract game names from each game object
+          const gameNames = { 
+            names: responseData.data.map((game: any) => game.attributes.game_name)
+          }
+          localStorage.setItem('CustomGames', JSON.stringify(gameNames));
+          console.log("fetched custom data", responseData.data);
+      
+        } catch(error) {
+          setError(error.message);
         }
-        const responseData = await response.json();
-  
-    
-        // Extract game names from each game object
-        const gameNames = responseData.data.map((game: any) => game.attributes.game_name);
-        
-        setCustomGames({
-          names: gameNames // Store game names in an array
-        
-        });
-    
-        console.log("fetched custom data", responseData.data);
-    
-      } catch(error) {
-        setError(error.message);
       }
+      setCustomGames(JSON.parse(localStorage.getItem("CustomGames")));
     };
     
-
-
     const fetchCompetitiveData = async () => {
-      try {
-        const response = await fetch(`https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/users/${storedUser.id}/competitive_stats`);
-        if (!response.ok) {
-          throw new Error('Failed to fetch competitive stats data');
+      if(!localStorage.getItem("CompetitiveData")) {
+        try {
+          const response = await fetch(`https://powerful-sierra-25067-22c20bb81d9c.herokuapp.com/api/v0/users/${storedUser.id}/competitive_stats`);
+          if (!response.ok) {
+            throw new Error('Failed to fetch competitive stats data');
+          }
+          const data = await response.json();
+
+
+          //format the scores in an array
+          const top5scores = data.competitive_stats.top_5_competitive_users
+            .map(user => user.score.toFixed(2))
+            .join(", ");
+
+            //an array of usernames
+          const top5usernames = data.competitive_stats.top_5_competitive_users
+            .map(user => user.username)
+            .join(", ");
+
+          const competitiveData = {
+            top5username: top5usernames,
+            top5score: top5scores,
+            userRank: data.competitive_stats.user_competitive_rank,
+            gameCount: data.competitive_stats.competitive_game_count,
+            avgCompScore: data.competitive_stats.average_score_in_competitive_games.toFixed(2),
+          };
+          localStorage.setItem('CompetitiveData', JSON.stringify(competitiveData))
+          console.log("fetched competitive stats data", data);
+        } catch (error) {
+          setError(error.message)
         }
-        const data = await response.json();
-
-
-        //format the scores in an array
-        const top5scores = data.competitive_stats.top_5_competitive_users
-          .map(user => user.score.toFixed(2))
-          .join(", ");
-
-          //an array of usernames
-        const top5usernames = data.competitive_stats.top_5_competitive_users
-          .map(user => user.username)
-          .join(", ");
-
-        setCompetitiveData({
-          top5username: top5usernames,
-          top5score: top5scores,
-          userRank: data.competitive_stats.user_competitive_rank,
-          gameCount: data.competitive_stats.competitive_game_count,
-          avgCompScore: data.competitive_stats.average_score_in_competitive_games.toFixed(2),
-        });
-
-        console.log("fetched competitive stats data", data);
-        setIsLoading(false)
-      } catch (error) {
-        setError(error.message)
       }
+      setIsLoading(false)
+      setCompetitiveData(JSON.parse(localStorage.getItem("CompetitiveData")));
     };
     fetchRoundData();
     fetchCustomData();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -106,5 +106,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+   "include": ["src", "node_modules/@types"]
 }


### PR DESCRIPTION
# Description
This fix is meant to reduce the number of API calls made when moving between pages. It should store important data locally so when navigating between daily round, Comp round, and Dashboard new API calls are not made each time.

# Contributors
@BrendanTurner1 

# Notes
Further functionality can be added by having a refresh for the stats to manually update. As well as a need to track the user vote location and status

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] My PR denotes any/all team members who contributed to it.
- [x] My code follows the Turing Style Guides and best practices.
- [x] I ran the code locally and verified that there are no visible errors.
- [ ] feat: My PR clearly describes what feature I'm adding and any changes needed to make it work. _(if applicable)_
- [x] fix: My PR clearly describes what bug I'm fixing and why. _(if applicable)_
